### PR TITLE
Add package testbarrier

### DIFF
--- a/testbarrier/BUILD.bazel
+++ b/testbarrier/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "testbarrier",
+    srcs = ["barrier.go"],
+    importpath = "protoctx/internal/testbarrier",
+    visibility = ["//:__subpackages__"],
+    deps = ["//internal/ensure"],
+)
+
+go_test(
+    name = "testbarrier_test",
+    size = "small",  # keep
+    srcs = ["barrier_test.go"],
+    deps = [":testbarrier"],
+)

--- a/testbarrier/barrier.go
+++ b/testbarrier/barrier.go
@@ -1,0 +1,47 @@
+// Package testbarrier implements a barrier for testing asynchronous systems.
+package testbarrier
+
+import (
+	"github.com/jespert/artk/mustbe"
+	"time"
+)
+
+// Barrier blocks tests for a limited duration until an event happens.
+type Barrier struct {
+	ch chan struct{}
+}
+
+// Lift the barrier. Must be called when the event happens.
+func (b Barrier) Lift() {
+	b.ch <- struct{}{}
+}
+
+// Wait for the barrier to lift for up to a duration `d`.
+// If the deadline expires, the test will fail immediately.
+func (b Barrier) Wait(t testingT, d time.Duration) {
+	mustbe.NotNil(t)
+
+	t.Helper()
+
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+
+	select {
+	case <-b.ch:
+		// All good.
+	case <-ticker.C:
+		t.Error("barrier timeout exceeded")
+		t.FailNow()
+	}
+}
+
+// New creates a Barrier.
+func New() Barrier {
+	return Barrier{ch: make(chan struct{})}
+}
+
+type testingT interface {
+	Error(args ...any)
+	FailNow()
+	Helper()
+}

--- a/testbarrier/barrier_test.go
+++ b/testbarrier/barrier_test.go
@@ -1,0 +1,48 @@
+package testbarrier_test
+
+import (
+	"github.com/jespert/artk/testbarrier"
+	"testing"
+	"time"
+)
+
+func TestBarrier_Lift(t *testing.T) {
+	barrier := testbarrier.New()
+	go barrier.Lift()
+	barrier.Wait(t, 100*365*24*time.Hour)
+}
+
+func TestBarrier_Wait_expires(t *testing.T) {
+	fakeT := &testingT{
+		onHelper:  make(chan struct{}),
+		onError:   make(chan struct{}),
+		onFailNow: make(chan struct{}),
+	}
+
+	go func() {
+		barrier := testbarrier.New()
+		barrier.Wait(fakeT, time.Nanosecond)
+	}()
+
+	<-fakeT.onHelper
+	<-fakeT.onError
+	<-fakeT.onFailNow
+}
+
+type testingT struct {
+	onHelper  chan struct{}
+	onError   chan struct{}
+	onFailNow chan struct{}
+}
+
+func (t *testingT) Helper() {
+	t.onHelper <- struct{}{}
+}
+
+func (t *testingT) Error(_ ...any) {
+	t.onError <- struct{}{}
+}
+
+func (t *testingT) FailNow() {
+	t.onFailNow <- struct{}{}
+}


### PR DESCRIPTION
Can be used to simplify the testing of asynchronous systems (e.g., E2E tests for distributed systems).