### PR TITLE
apperror: support arguments in constructors

### DIFF
--- a/apperror/conflict.go
+++ b/apperror/conflict.go
@@ -1,6 +1,9 @@
 package apperror
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type conflictErr struct {
 	error
@@ -15,8 +18,8 @@ func (e conflictErr) Kind() Kind {
 }
 
 // Conflict creates a new conflict error.
-func Conflict(msg string) error {
-	return &conflictErr{error: errors.New(msg)}
+func Conflict(msg string, a ...any) error {
+	return &conflictErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsConflict checks if the error is a conflict error.

--- a/apperror/conflict_test.go
+++ b/apperror/conflict_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestConflict(t *testing.T) {
-	err := apperror.Conflict("test error")
+	err := apperror.Conflict("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.ConflictKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}

--- a/apperror/forbidden.go
+++ b/apperror/forbidden.go
@@ -1,6 +1,9 @@
 package apperror
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type forbiddenErr struct {
 	error
@@ -15,8 +18,8 @@ func (e forbiddenErr) Kind() Kind {
 }
 
 // Forbidden creates a new forbidden error.
-func Forbidden(msg string) error {
-	return &forbiddenErr{error: errors.New(msg)}
+func Forbidden(msg string, a ...any) error {
+	return &forbiddenErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsForbidden checks if the error is a forbidden error.

--- a/apperror/forbidden_test.go
+++ b/apperror/forbidden_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestForbidden(t *testing.T) {
-	err := apperror.Forbidden("test error")
+	err := apperror.Forbidden("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.ForbiddenKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}

--- a/apperror/not_found.go
+++ b/apperror/not_found.go
@@ -2,6 +2,7 @@ package apperror
 
 import (
 	"errors"
+	"fmt"
 )
 
 type notFoundErr struct {
@@ -17,8 +18,8 @@ func (e notFoundErr) Kind() Kind {
 }
 
 // NotFound creates a new not found error.
-func NotFound(msg string) error {
-	return &notFoundErr{error: errors.New(msg)}
+func NotFound(msg string, a ...any) error {
+	return &notFoundErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsNotFound checks if the error is a not found error.

--- a/apperror/not_found_test.go
+++ b/apperror/not_found_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNotFound(t *testing.T) {
-	err := apperror.NotFound("test error")
+	err := apperror.NotFound("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.NotFoundKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}

--- a/apperror/not_modified.go
+++ b/apperror/not_modified.go
@@ -1,6 +1,9 @@
 package apperror
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type notModifiedErr struct {
 	error
@@ -16,8 +19,8 @@ func (e notModifiedErr) Kind() Kind {
 
 // NotModified creates a new not modified error.
 // This is usually a sentinel error and does not indicate a problem.
-func NotModified(msg string) error {
-	return &notModifiedErr{error: errors.New(msg)}
+func NotModified(msg string, a ...any) error {
+	return &notModifiedErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsNotModified checks if the error is a not modified error.

--- a/apperror/not_modified_test.go
+++ b/apperror/not_modified_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNotModified(t *testing.T) {
-	err := apperror.NotModified("test error")
+	err := apperror.NotModified("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.NotModifiedKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}

--- a/apperror/precondition_failed.go
+++ b/apperror/precondition_failed.go
@@ -1,6 +1,9 @@
 package apperror
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type preconditionFailedErr struct {
 	error
@@ -15,8 +18,8 @@ func (e preconditionFailedErr) Kind() Kind {
 }
 
 // PreconditionFailed creates a new precondition failed error.
-func PreconditionFailed(msg string) error {
-	return &preconditionFailedErr{error: errors.New(msg)}
+func PreconditionFailed(msg string, a ...any) error {
+	return &preconditionFailedErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsPreconditionFailed checks if the error is a precondition failed error.

--- a/apperror/precondition_failed_test.go
+++ b/apperror/precondition_failed_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPreconditionFailed(t *testing.T) {
-	err := apperror.PreconditionFailed("test error")
+	err := apperror.PreconditionFailed("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.PreconditionFailedKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}

--- a/apperror/timeout.go
+++ b/apperror/timeout.go
@@ -1,6 +1,9 @@
 package apperror
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type timeoutErr struct {
 	error
@@ -15,8 +18,8 @@ func (e timeoutErr) Kind() Kind {
 }
 
 // Timeout creates a new timeout error.
-func Timeout(msg string) error {
-	return &timeoutErr{error: errors.New(msg)}
+func Timeout(msg string, a ...any) error {
+	return &timeoutErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsTimeout checks if the error is a timeout error.

--- a/apperror/timeout_test.go
+++ b/apperror/timeout_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTimeout(t *testing.T) {
-	err := apperror.Timeout("test error")
+	err := apperror.Timeout("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.TimeoutKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}

--- a/apperror/too_many_requests.go
+++ b/apperror/too_many_requests.go
@@ -1,6 +1,9 @@
 package apperror
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type tooManyRequestsErr struct {
 	error
@@ -15,8 +18,8 @@ func (e tooManyRequestsErr) Kind() Kind {
 }
 
 // TooManyRequests creates a new too many requests error.
-func TooManyRequests(msg string) error {
-	return &tooManyRequestsErr{error: errors.New(msg)}
+func TooManyRequests(msg string, a ...any) error {
+	return &tooManyRequestsErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsTooManyRequests checks if the error is a too many requests error.

--- a/apperror/too_many_requests_test.go
+++ b/apperror/too_many_requests_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestTooManyRequests(t *testing.T) {
-	err := apperror.TooManyRequests("test error")
+	err := apperror.TooManyRequests("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.TooManyRequestsKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}

--- a/apperror/unauthorized.go
+++ b/apperror/unauthorized.go
@@ -1,6 +1,9 @@
 package apperror
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type unauthorizedErr struct {
 	error
@@ -15,8 +18,8 @@ func (e unauthorizedErr) Kind() Kind {
 }
 
 // Unauthorized creates a new unauthorized error.
-func Unauthorized(msg string) error {
-	return &unauthorizedErr{error: errors.New(msg)}
+func Unauthorized(msg string, a ...any) error {
+	return &unauthorizedErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsUnauthorized checks if the error is a unauthorized error.

--- a/apperror/unauthorized_test.go
+++ b/apperror/unauthorized_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestUnauthorized(t *testing.T) {
-	err := apperror.Unauthorized("test error")
+	err := apperror.Unauthorized("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.UnauthorizedKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}

--- a/apperror/validation.go
+++ b/apperror/validation.go
@@ -1,6 +1,9 @@
 package apperror
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type validationErr struct {
 	error
@@ -15,8 +18,8 @@ func (e validationErr) Kind() Kind {
 }
 
 // Validation creates a new validation error.
-func Validation(msg string) error {
-	return &validationErr{error: errors.New(msg)}
+func Validation(msg string, a ...any) error {
+	return &validationErr{error: fmt.Errorf(msg, a...)}
 }
 
 // IsValidation checks fit he error is a validation error.

--- a/apperror/validation_test.go
+++ b/apperror/validation_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestValidation(t *testing.T) {
-	err := apperror.Validation("test error")
+	err := apperror.Validation("%v error", "test")
 	if k := apperror.KindOf(err); k != apperror.ValidationKind {
 		t.Errorf("unexpected kind, got %v", k)
 	}


### PR DESCRIPTION
Allows creating more informative errors without an extra call to `fmt.Sprintf`.