### PR TITLE
/doc.go: rename package from core to artk

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,3 @@
-// Package core contains the ARTK components that depend exclusively on the
+// Package artk contains the ARTK components that depend exclusively on the
 // Go standard library.
-package core
+package artk


### PR DESCRIPTION
Fixes an oversight.