### PR TITLE
assume_test.go: rename TestNoError to TestSuccess

### DIFF
--- a/assume/assume_test.go
+++ b/assume/assume_test.go
@@ -27,7 +27,7 @@ func TestEqual(t *testing.T) {
 	})
 }
 
-func TestNoError(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	t.Run("Do not panic if nil", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r != nil {


### PR DESCRIPTION
Fixes an oversight.