### PR TITLE
README.md: fix link to goreportcard.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Report Card](https://goreportcard.com/badge/artk.dev)](https://goreportcard.com/badge/artk.dev) [![License](https://img.shields.io/github/license/jespert/artk)](https://github.com/jespert/artk/blob/main/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/artk.dev)](https://goreportcard.com/report/artk.dev) [![License](https://img.shields.io/github/license/jespert/artk)](https://github.com/jespert/artk/blob/main/LICENSE)
 
 # artk
 Architecture Toolkit for Go


### PR DESCRIPTION
It was linking to the badge, not the report.