### PR TITLE
eventmux: add helpers_test.go

### DIFF
--- a/eventmux/helpers_test.go
+++ b/eventmux/helpers_test.go
@@ -1,0 +1,69 @@
+package eventmux_test
+
+import (
+	"artk.dev/eventmux"
+	"artk.dev/testbarrier"
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func assertIsDeepCopy[Event any](t *testing.T, originalEvent Event) {
+	const numObservers = 2
+	var receivedEvents [numObservers]Event
+	var wg sync.WaitGroup
+	wg.Add(numObservers)
+
+	t.Log("Given that there are two observers,")
+	mux := eventmux.New[Event]()
+	for i := range receivedEvents {
+		mux.WillNotify(func(_ context.Context, e Event) error {
+			defer wg.Done()
+			receivedEvents[i] = e
+			return nil
+		})
+	}
+
+	t.Log("When Mux observes an event,")
+	err := mux.Observe(context.TODO(), originalEvent)
+	if err != nil {
+		t.Error("unexpected error:", err)
+	}
+
+	testbarrier.WaitForGroup(t, &wg, 5*time.Second)
+
+	t.Log("Then the events sent to the observers are deep copies.")
+	if same(receivedEvents[0], receivedEvents[1]) {
+		t.Error("The received event are shallow copies")
+	}
+	if same(originalEvent, receivedEvents[0]) {
+		t.Error("The first event is a shallow copy")
+	}
+	if same(originalEvent, receivedEvents[1]) {
+		t.Error("The second event is a shallow copy")
+	}
+}
+
+func exampleEvent() Event {
+	return Event{
+		ID:   expectedID,
+		Name: expectedName,
+	}
+}
+
+func same(x, y any) bool {
+	vx := reflect.ValueOf(x)
+	vy := reflect.ValueOf(y)
+	if !vx.IsValid() {
+		return !vy.IsValid()
+	}
+
+	return vx.Pointer() == vy.Pointer()
+}
+
+const expectedID = 1234
+const expectedName = "Test Event"
+
+type key struct{}

--- a/eventmux/mux_test.go
+++ b/eventmux/mux_test.go
@@ -6,7 +6,6 @@ import (
 	"artk.dev/testbarrier"
 	"context"
 	"errors"
-	"reflect"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -124,42 +123,6 @@ func TestMux_Observe_deep_copies_events(t *testing.T) {
 			"baz": 3,
 		})
 	})
-}
-
-func assertIsDeepCopy[Event any](t *testing.T, originalEvent Event) {
-	const numObservers = 2
-	var receivedEvents [numObservers]Event
-	var wg sync.WaitGroup
-	wg.Add(numObservers)
-
-	t.Log("Given that there are two observers,")
-	mux := eventmux.New[Event]()
-	for i := range receivedEvents {
-		mux.WillNotify(func(_ context.Context, e Event) error {
-			defer wg.Done()
-			receivedEvents[i] = e
-			return nil
-		})
-	}
-
-	t.Log("When Mux observes an event,")
-	err := mux.Observe(context.TODO(), originalEvent)
-	if err != nil {
-		t.Error("unexpected error:", err)
-	}
-
-	testbarrier.WaitForGroup(t, &wg, 5*time.Second)
-
-	t.Log("Then the events sent to the observers are deep copies.")
-	if same(receivedEvents[0], receivedEvents[1]) {
-		t.Error("The received event are shallow copies")
-	}
-	if same(originalEvent, receivedEvents[0]) {
-		t.Error("The first event is a shallow copy")
-	}
-	if same(originalEvent, receivedEvents[1]) {
-		t.Error("The second event is a shallow copy")
-	}
 }
 
 func TestMux_Shutdown_allows_all_tasks_to_terminate(t *testing.T) {
@@ -398,25 +361,3 @@ func TestMux_context_middleware_happens_before_observer(t *testing.T) {
 
 	barrier.Wait(t, 5*time.Second)
 }
-
-func exampleEvent() Event {
-	return Event{
-		ID:   expectedID,
-		Name: expectedName,
-	}
-}
-
-func same(x, y any) bool {
-	vx := reflect.ValueOf(x)
-	vy := reflect.ValueOf(y)
-	if !vx.IsValid() {
-		return !vy.IsValid()
-	}
-
-	return vx.Pointer() == vy.Pointer()
-}
-
-const expectedID = 1234
-const expectedName = "Test Event"
-
-type key struct{}


### PR DESCRIPTION
Move test helpers there, where we can reuse them for other broker
implementations.