### PR TITLE
Breaking change: rename package eventmux to event

### DIFF
--- a/event/doc.go
+++ b/event/doc.go
@@ -1,0 +1,2 @@
+// Package event provides in-memory event brokers.
+package event

--- a/event/helpers_test.go
+++ b/event/helpers_test.go
@@ -1,7 +1,7 @@
-package eventmux_test
+package event_test
 
 import (
-	"artk.dev/eventmux"
+	"artk.dev/event"
 	"artk.dev/testbarrier"
 	"context"
 	"reflect"
@@ -17,7 +17,7 @@ func assertIsDeepCopy[Event any](t *testing.T, originalEvent Event) {
 	wg.Add(numObservers)
 
 	t.Log("Given that there are two observers,")
-	mux := eventmux.New[Event]()
+	mux := event.NewMux[Event]()
 	for i := range receivedEvents {
 		mux.WillNotify(func(_ context.Context, e Event) error {
 			defer wg.Done()

--- a/event/interfaces.go
+++ b/event/interfaces.go
@@ -1,4 +1,4 @@
-package eventmux
+package event
 
 import "context"
 

--- a/event/mux.go
+++ b/event/mux.go
@@ -1,4 +1,4 @@
-package eventmux
+package event
 
 import (
 	"artk.dev/asynctx"
@@ -155,7 +155,7 @@ func (m *Mux[Event]) stopEventPropagation() {
 	m.observers = nil
 }
 
-// New creates a Mux.
-func New[Event any]() *Mux[Event] {
+// NewMux creates a Mux.
+func NewMux[Event any]() *Mux[Event] {
 	return &Mux[Event]{}
 }

--- a/event/none.go
+++ b/event/none.go
@@ -1,4 +1,4 @@
-package eventmux
+package event
 
 import "context"
 
@@ -10,7 +10,7 @@ import "context"
 // Example:
 //
 //	// Construction.
-//	h.listener = eventmux.None[MyEvent]
+//	h.listener = event.None[MyEvent]
 //
 //	// Usage (no need to check if `listener` is nil).
 //	h.listener(ctx, e)

--- a/event/none_test.go
+++ b/event/none_test.go
@@ -1,13 +1,13 @@
-package eventmux_test
+package event_test
 
 import (
-	"artk.dev/eventmux"
+	"artk.dev/event"
 	"context"
 	"testing"
 )
 
 func TestNone(t *testing.T) {
-	err := eventmux.None[Event](context.TODO(), exampleEvent())
+	err := event.None[Event](context.TODO(), exampleEvent())
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}

--- a/eventmux/doc.go
+++ b/eventmux/doc.go
@@ -1,2 +1,0 @@
-// Package eventmux provides an in-memory event multiplexer.
-package eventmux

--- a/x/eventlog/go.mod
+++ b/x/eventlog/go.mod
@@ -3,7 +3,7 @@ module artk.dev/x/eventlog
 go 1.22.0
 
 require (
-	artk.dev v0.3.0
+	artk.dev v0.4.0
 	artk.dev/x/testlog v0.2.0
 )
 


### PR DESCRIPTION
Release: v0.4.0 x/eventlog/v0.3.0

Also: rename New to NewMux.

This paves the way for the introduction of alternative brokers.