### PR TITLE
testbarrier: once lifted, the barrier never waits

### DIFF
--- a/testbarrier/barrier.go
+++ b/testbarrier/barrier.go
@@ -13,7 +13,7 @@ type Barrier struct {
 
 // Lift the barrier. Must be called when the event happens.
 func (b Barrier) Lift() {
-	b.ch <- struct{}{}
+	close(b.ch)
 }
 
 // Wait for the barrier to lift for up to a duration `d`.

--- a/testbarrier/barrier_test.go
+++ b/testbarrier/barrier_test.go
@@ -48,3 +48,14 @@ func TestBarrier_Wait_calls_FailNow_if_timeout_expires(t *testing.T) {
 		t.Errorf("property was not satisfied within timeout")
 	}
 }
+
+func TestBarrier_Wait_never_blocks_after_Lift(t *testing.T) {
+	t.Parallel()
+
+	barrier := testbarrier.New()
+	go barrier.Lift()
+
+	for range 100 {
+		barrier.Wait(t, 100*365*24*time.Hour)
+	}
+}


### PR DESCRIPTION
Before it was only possible to wait for the barrier once, which is
not sufficient for easily handling every scenario.