### PR TITLE
Breaking change: stream: use the function options pattern in NewStream

### DIFF
--- a/event/stream_test.go
+++ b/event/stream_test.go
@@ -375,7 +375,7 @@ func TestStream_messages_are_dropped_when_queue_size_exceeded(t *testing.T) {
 func testStreamMessageDrop(t *testing.T, queueSize int32) {
 	t.Helper()
 
-	stream := event.NewStream[Event](queueSize)
+	stream := event.NewStream[Event](event.WithStreamQueueSize(queueSize))
 
 	var numEventsObserved int
 	barrier := testbarrier.New()


### PR DESCRIPTION
Release: v0.5.0

This allows users to use the default queue size when calling NewStream.
Since that size is a private implementation detail, users were
previously lacking that ability.