### PR TITLE
GitHub Actions: test against both Go 1.23 and 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,7 @@ jobs:
     strategy:
       matrix:
         go-version:
+          - "1.23"
           - "1.22"
 
     steps:
@@ -40,7 +41,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58.1
+          version: v1.61.0
           args: "--help" # Install the tool, but don't run it.
 
       - name: Install gotestsum

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,8 +11,6 @@ linters:
     - durationcheck
     - errcheck
     - errchkjson
-    #- execinquery  # deprecated
-    - exportloopref
     - gocognit
     - goconst
     - gocritic

--- a/apperror/apperror.go
+++ b/apperror/apperror.go
@@ -1,6 +1,7 @@
 package apperror
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -41,9 +42,15 @@ func As(kind Kind, err error) error {
 // New creates an error of the specified Kind.
 // Invalid Kind values are mapped to Unknown.
 // If the kind is OK, the function will return nil.
-func New(kind Kind, msg string, a ...any) error {
-	err := fmt.Errorf(msg, a...)
-	return As(kind, err)
+func New(kind Kind, msg string) error {
+	return As(kind, errors.New(msg))
+}
+
+// Newf creates an error of the specified Kind with a formatted string.
+// Invalid Kind values are mapped to Unknown.
+// If the kind is OK, the function will return nil.
+func Newf(kind Kind, msg string, a ...any) error {
+	return As(kind, fmt.Errorf(msg, a...))
 }
 
 // IsFinal returns true for error kinds that are not expected to change by

--- a/apperror/apperror_test.go
+++ b/apperror/apperror_test.go
@@ -338,14 +338,14 @@ func TestNew_honors_kind(t *testing.T) {
 func TestNew_honors_message(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name(), func(t *testing.T) {
-			err := apperror.New(tc.kind, "%v error", "test")
+			err := apperror.Newf(tc.kind, "%v error", "test")
 			assertTestMessage(t, err)
 		})
 	}
 }
 
 func TestNew_returns_nil_for_OK(t *testing.T) {
-	err := apperror.New(apperror.OK, "%v error", "test")
+	err := apperror.Newf(apperror.OK, "%v error", "test")
 	if err != nil {
 		t.Error("expected nil, got:", err)
 	}

--- a/event/stream_test.go
+++ b/event/stream_test.go
@@ -364,10 +364,10 @@ func TestStream_context_middleware_happens_before_observer(t *testing.T) {
 }
 
 func TestStream_messages_are_dropped_when_queue_size_exceeded(t *testing.T) {
-	const maxTestedQueueSize = 256
+	const maxTestedQueueSize int32 = 256
 	for i := range maxTestedQueueSize {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			testStreamMessageDrop(t, int32(i))
+		t.Run(strconv.Itoa(int(i)), func(t *testing.T) {
+			testStreamMessageDrop(t, i)
 		})
 	}
 }


### PR DESCRIPTION
Release: v0.6.0

We want to follow upstream in supporting the two most recent major
versions of Go.