### PR TITLE
GitHub Actions: add go version and GitHub ref to test report

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,6 +70,8 @@ jobs:
         uses: dorny/test-reporter@v1
         if: always()
         with:
-          name: Test report
+          # We shouldn't need the ref, but GitHub refuses to fix a bug:
+          # See https://github.com/orgs/community/discussions/24616
+          name: "Test report ${{ matrix.go-version }} (${{ github.ref }})"
           path: junit.xml
           reporter: java-junit


### PR DESCRIPTION
The latter shouldn't be necessary, but is due to a silly bug that
GitHub refuses to fix.

See https://github.com/orgs/community/discussions/24616